### PR TITLE
[Optimization] Cjmels/allow example level splitting

### DIFF
--- a/lib/knapsack/adapters/rspec_adapter.rb
+++ b/lib/knapsack/adapters/rspec_adapter.rb
@@ -62,10 +62,8 @@ module Knapsack
           end
         end
 
-        require 'pry'; binding.pry
-        slow_spec_list = ENV['SLOW_SPECS']&.split(',')&.flat_map { |spec| ["#{spec}[1:1]", "#{spec}[1:2]"] } || []
+        slow_spec_list = Knapsack::Config::Env.slow_spec_examples
         if slow_spec_list.any? { |slow_file_with_group| slow_file_with_group =~ Regexp.new(example_group[:file_path].sub(/^\.\//, '')) }
-          require 'pry'; binding.pry
           "#{example_group[:file_path]}[#{original_example_group[:scoped_id].split(':').first(2).join(':')}]"
         else
           example_group[:file_path]

--- a/lib/knapsack/adapters/rspec_adapter.rb
+++ b/lib/knapsack/adapters/rspec_adapter.rb
@@ -62,8 +62,11 @@ module Knapsack
           end
         end
 
-        slow_spec_files = Knapsack::Config::Env.slow_spec_files
-        if slow_spec_files.any? { |slow_spec_path| example_group[:file_path] =~ Regexp.new(slow_spec_path) }
+        slow_spec_examples = Knapsack::Config::Env.slow_spec_examples
+        match_slow_spec_examples = slow_spec_examples.any? do |slow_spec_example|
+          slow_spec_example =~ Regexp.new(example_group[:file_path].sub(/^\.\//, ''))
+        end
+        if match_slow_spec_examples
           "#{example_group[:file_path]}[#{original_example_group[:scoped_id].split(':').first(2).join(':')}]"
         else
           example_group[:file_path]

--- a/lib/knapsack/adapters/rspec_adapter.rb
+++ b/lib/knapsack/adapters/rspec_adapter.rb
@@ -62,8 +62,8 @@ module Knapsack
           end
         end
 
-        slow_spec_list = Knapsack::Config::Env.slow_spec_examples
-        if slow_spec_list.any? { |slow_file_with_group| slow_file_with_group =~ Regexp.new(example_group[:file_path].sub(/^\.\//, '')) }
+        slow_spec_files = Knapsack::Config::Env.slow_spec_files
+        if slow_spec_files.any? { |slow_spec_path| example_group[:file_path] =~ Regexp.new(slow_spec_path) }
           "#{example_group[:file_path]}[#{original_example_group[:scoped_id].split(':').first(2).join(':')}]"
         else
           example_group[:file_path]

--- a/lib/knapsack/adapters/rspec_adapter.rb
+++ b/lib/knapsack/adapters/rspec_adapter.rb
@@ -48,6 +48,8 @@ module Knapsack
       end
 
       def self.test_path(example_group)
+        original_example_group = example_group
+
         if defined?(Turnip) && Turnip::VERSION.to_i < 2
           unless example_group[:turnip]
             until example_group[:parent_example_group].nil?
@@ -60,7 +62,14 @@ module Knapsack
           end
         end
 
-        example_group[:file_path]
+        require 'pry'; binding.pry
+        slow_spec_list = ENV['SLOW_SPECS']&.split(',')&.flat_map { |spec| ["#{spec}[1:1]", "#{spec}[1:2]"] } || []
+        if slow_spec_list.any? { |slow_file_with_group| slow_file_with_group =~ Regexp.new(example_group[:file_path].sub(/^\.\//, '')) }
+          require 'pry'; binding.pry
+          "#{example_group[:file_path]}[#{original_example_group[:scoped_id].split(':').first(2).join(':')}]"
+        else
+          example_group[:file_path]
+        end
       end
     end
 

--- a/lib/knapsack/config/env.rb
+++ b/lib/knapsack/config/env.rb
@@ -30,6 +30,18 @@ module Knapsack
           }[ENV['KNAPSACK_LOG_LEVEL']] || Knapsack::Logger::INFO
         end
 
+        def slow_spec_examples
+          if ENV['SLOW_SPEC_EXAMPLES']
+            ENV['SLOW_SPEC_EXAMPLES'].split(',')
+          else
+            []
+          end
+        end
+
+        def slow_spec_files
+          slow_spec_examples.map { |example| example.split('[').first }.uniq
+        end
+
         private
 
         def index_starting_from_one(index)

--- a/lib/knapsack/config/env.rb
+++ b/lib/knapsack/config/env.rb
@@ -39,7 +39,7 @@ module Knapsack
         end
 
         def slow_spec_files
-          slow_spec_examples.map { |example| example.split('[').first }.uniq
+          @slow_spec_files ||= slow_spec_examples.map { |example| example.split('[').first }.uniq
         end
 
         private

--- a/lib/knapsack/distributors/base_distributor.rb
+++ b/lib/knapsack/distributors/base_distributor.rb
@@ -37,7 +37,7 @@ module Knapsack
       end
 
       def all_tests
-        @all_tests ||= (Dir.glob(test_file_pattern) + (ENV['SLOW_SPECS']&.split(',')&.flat_map { |spec| ["#{spec}[1:1]", "#{spec}[1:2]"] } || [])).uniq.sort
+        @all_tests ||= (Dir.glob(test_file_pattern) + Knapsack::Config::Env.slow_spec_examples).uniq.sort
       end
 
       protected

--- a/lib/knapsack/distributors/base_distributor.rb
+++ b/lib/knapsack/distributors/base_distributor.rb
@@ -37,9 +37,7 @@ module Knapsack
       end
 
       def all_tests
-        @all_tests ||= (Dir.glob(test_file_pattern) + Knapsack::Config::Env.slow_spec_examples).uniq.sort
-        puts ">>>>>>>>>>>>>>>>>>>>>>> all_tests: #{@all_tests}"
-        @all_tests
+        @all_tests ||= (Dir.glob(test_file_pattern).reject { |test_file| Knapsack::Config::Env.slow_spec_files.any? { |slow_spec_path| test_file =~ Regexp.new(slow_spec_path) }  } + Knapsack::Config::Env.slow_spec_examples).uniq.sort
       end
 
       protected

--- a/lib/knapsack/distributors/base_distributor.rb
+++ b/lib/knapsack/distributors/base_distributor.rb
@@ -38,6 +38,8 @@ module Knapsack
 
       def all_tests
         @all_tests ||= (Dir.glob(test_file_pattern) + Knapsack::Config::Env.slow_spec_examples).uniq.sort
+        puts ">>>>>>>>>>>>>>>>>>>>>>> all_tests: #{@all_tests}"
+        @all_tests
       end
 
       protected

--- a/lib/knapsack/distributors/base_distributor.rb
+++ b/lib/knapsack/distributors/base_distributor.rb
@@ -37,7 +37,7 @@ module Knapsack
       end
 
       def all_tests
-        @all_tests ||= Dir.glob(test_file_pattern).uniq.sort
+        @all_tests ||= (Dir.glob(test_file_pattern) + (ENV['SLOW_SPECS']&.split(',')&.flat_map { |spec| ["#{spec}[1:1]", "#{spec}[1:2]"] } || [])).uniq.sort
       end
 
       protected

--- a/lib/knapsack/distributors/leftover_distributor.rb
+++ b/lib/knapsack/distributors/leftover_distributor.rb
@@ -6,7 +6,7 @@ module Knapsack
       end
 
       def leftover_tests
-        @leftover_tests ||= all_tests - report_tests
+        @leftover_tests ||= all_tests - report_tests - (ENV['SLOW_SPECS']&.split(',') || [])
       end
 
       private

--- a/lib/knapsack/distributors/leftover_distributor.rb
+++ b/lib/knapsack/distributors/leftover_distributor.rb
@@ -6,7 +6,7 @@ module Knapsack
       end
 
       def leftover_tests
-        @leftover_tests ||= all_tests - report_tests - (ENV['SLOW_SPECS']&.split(',') || [])
+        @leftover_tests ||= (all_tests - report_tests).reject { |test_path| Knapsack::Config::Env.slow_spec_files.any? { |slow_spec_path| slow_spec_path =~ Regexp.new(test_path.sub(/^\.\//, ''))} }
       end
 
       private

--- a/lib/knapsack/distributors/leftover_distributor.rb
+++ b/lib/knapsack/distributors/leftover_distributor.rb
@@ -6,7 +6,12 @@ module Knapsack
       end
 
       def leftover_tests
-        @leftover_tests ||= (all_tests - report_tests).reject { |test_path| Knapsack::Config::Env.slow_spec_files.any? { |slow_spec_path| slow_spec_path =~ Regexp.new(test_path.sub(/^\.\//, ''))} }
+        @leftover_tests ||= (all_tests - report_tests)
+          .reject do |test_path|
+            !test_path.include?('[') && Knapsack::Config::Env.slow_spec_files.any? { |slow_spec_path| test_path =~ Regexp.new(slow_spec_path)}
+          end
+        puts ">>>>>>>>>>>>>>>>>>>>>>> leftover_tests: #{@leftover_tests}"
+        @leftover_tests
       end
 
       private

--- a/lib/knapsack/distributors/leftover_distributor.rb
+++ b/lib/knapsack/distributors/leftover_distributor.rb
@@ -6,12 +6,7 @@ module Knapsack
       end
 
       def leftover_tests
-        @leftover_tests ||= (all_tests - report_tests)
-          .reject do |test_path|
-            !test_path.include?('[') && Knapsack::Config::Env.slow_spec_files.any? { |slow_spec_path| test_path =~ Regexp.new(slow_spec_path)}
-          end
-        puts ">>>>>>>>>>>>>>>>>>>>>>> leftover_tests: #{@leftover_tests}"
-        @leftover_tests
+        @leftover_tests ||= (all_tests - report_tests - Knapsack::Config::Env.slow_spec_examples)
       end
 
       private

--- a/lib/knapsack/distributors/leftover_distributor.rb
+++ b/lib/knapsack/distributors/leftover_distributor.rb
@@ -6,7 +6,7 @@ module Knapsack
       end
 
       def leftover_tests
-        @leftover_tests ||= (all_tests - report_tests - Knapsack::Config::Env.slow_spec_examples)
+        @leftover_tests ||= all_tests - report_tests
       end
 
       private


### PR DESCRIPTION
#### Summary

Tech Debt Squad (24-30 July 2020)

Purpose: To be able to split slow rspec files into smaller chunks and test separately

How:
1. Takes in environment variable
`SLOW_SPEC_EXAMPLES="spec/models/shift_spec.rb[1:1],spec/models/shift_spec.rb[1:2]"`
2. Distributes slow spec examples into different containers
3. Generate report based on slow spec example groups
```
{
  ...
  "spec/models/shift_spec.rb[1:1]": 100.1,
  "spec/models/shift_spec.rb[1:2]": 100.2,
  ...
}
```

Currently only supports 2nd top level example groups

Paired with: (@CJBridges )

#### Test Plan

- [x] Tested on local with super_samurai 
- [x] Tested on circleci

https://app.circleci.com/pipelines/github/EnjoyTech/super_samurai/13091/workflows/11e15405-ea56-4e7e-ad75-62b4cbf19edd/jobs/646712
Container 44 - 47



----

#### Security

If you check one of the following, please send an email to nightwatch@enjoy.com for review. This change...

- [ ] collects more than the minimum amount of personal data necessary to provide the feature or service to fulfill the specific business purpose
- [ ] uses personal data for more than the specific business purpose
- [ ] adds access to personal data that is not auditable
- [ ] modifies security settings to grant more access to personally identifiable information (PII)

