### PR TITLE
[Optimization] use SLOW_SPEC_EXAMPLES_JSON for easier adding of slow specs

### DIFF
--- a/lib/knapsack/config/env.rb
+++ b/lib/knapsack/config/env.rb
@@ -31,7 +31,13 @@ module Knapsack
         end
 
         def slow_spec_examples
-          if ENV['SLOW_SPEC_EXAMPLES']
+          if ENV['SLOW_SPEC_EXAMPLES_JSON']
+            require 'json'
+            slow_spec_examples_hash = JSON.parse(File.read(ENV['SLOW_SPEC_EXAMPLES_JSON']))
+            slow_spec_examples_hash.flat_map do |file_path, scoped_ids|
+              scoped_ids.map { |scoped_id| "#{file_path}[#{scoped_id}]" }
+            end
+          elsif ENV['SLOW_SPEC_EXAMPLES']
             ENV['SLOW_SPEC_EXAMPLES'].split(',')
           else
             []

--- a/lib/knapsack/distributors/base_distributor.rb
+++ b/lib/knapsack/distributors/base_distributor.rb
@@ -37,7 +37,21 @@ module Knapsack
       end
 
       def all_tests
-        @all_tests ||= (Dir.glob(test_file_pattern).reject { |test_file| Knapsack::Config::Env.slow_spec_files.any? { |slow_spec_path| test_file =~ Regexp.new(slow_spec_path) }  } + Knapsack::Config::Env.slow_spec_examples).uniq.sort
+        @all_tests ||= (
+          Dir.glob(test_file_pattern)
+            .flat_map { |test_file| 
+              slow_spec_file = slow_spec_file_for(test_file)
+              if slow_spec_file.nil?
+                [test_file]
+              else
+                Knapsack::Config::Env.slow_spec_examples.map { |slow_spec_example| slow_spec_example.sub(slow_spec_file, test_file) }
+              end
+            } 
+        ).uniq.sort
+      end
+
+      def slow_spec_file_for(test_file)
+        Knapsack::Config::Env.slow_spec_files.find { |slow_spec_path| test_file =~ Regexp.new(slow_spec_path) }
       end
 
       protected

--- a/lib/knapsack/distributors/base_distributor.rb
+++ b/lib/knapsack/distributors/base_distributor.rb
@@ -51,7 +51,7 @@ module Knapsack
       end
 
       def slow_spec_file_for(test_file)
-        Knapsack::Config::Env.slow_spec_files.find { |slow_spec_path| test_file =~ Regexp.new(slow_spec_path) }
+        Knapsack::Config::Env.slow_spec_files.detect { |slow_spec_path| test_file =~ Regexp.new(slow_spec_path) }
       end
 
       protected


### PR DESCRIPTION
#### Summary

1. Added check for new env variable SLOW_SPEC_EXAMPLES_JSON
which stores the JSON file path for the list of 2nd highest example groups

2. Changed the input format of the slow spec file path to only include relative to project folder

#### Test Plan

Include steps on how the changes in this PR were tested in local or staging environment.



- [x] Tested with super_samurai on local
```
export SLOW_SPEC_FILES="spec/models/visit_spec.rb" SLOW_SPEC_FILE_PREFIX="" SLOW_SPEC_EXAMPLES_JSON=slow_spec_examples.json && bin/rspec --dry-run --require ./spec/support/formatters/knapsack_examples_in_json_formatter --format KnapsackExamplesInJsonFormatter $SLOW_SPEC_FILES && export KNAPSACK_TEST_DIR=spec KNAPSACK_GENERATE_REPORT=true KNAPSACK_TEST_FILE_PATTERN="./{spec/models/visit_spec.rb,spec/forms/null_forms/empty_spec.rb}" CIRCLECI=true SLOW_SPEC_FILES="spec/models/visit_spec.rb" SLOW_SPEC_EXAMPLES_JSON="slow_spec_examples.json"  SLOW_SPEC_FILE_PREFIX="" && bundle exec knapsack rspec
```
- [x] Works as expected on circleci
Checked that cache timings works as expected


----

#### Security

If you check one of the following, please send an email to nightwatch@enjoy.com for review. This change...

- [ ] collects more than the minimum amount of personal data necessary to provide the feature or service to fulfill the specific business purpose
- [ ] uses personal data for more than the specific business purpose
- [ ] adds access to personal data that is not auditable
- [ ] modifies security settings to grant more access to personally identifiable information (PII)

